### PR TITLE
patch: PATCH_DIR as absolute path

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -6,7 +6,7 @@
 
 TOP=${PWD}
 source $TOP/build/envsetup.sh > /dev/null 2>&1
-PATCH_DIR=$( dirname "${BASH_SOURCE[0]}" )
+PATCH_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 NOCOLOR='\033[0m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
Something that works for me perfectly fine in many scripts.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>